### PR TITLE
Validate zip file before cleaning the hosting folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = 'Use Python to manage Nginx on the machine.'
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
+license = { file = "LICENSE.txt" }
 keywords = []
 authors = [
   { name = "Trương Hải Đăng", email = "haidanghth910@gmail.com" },


### PR DESCRIPTION
This pull request improves the safety and robustness of the source archive upload process in the `py_manage_nginx` package, and makes a minor update to the project metadata. The most important changes are grouped below:

**Safety and Validation Improvements:**

* The `upload_source_archive` function now validates the archive format before any destructive operation (such as deleting the existing document root). This prevents accidental data loss from invalid uploads.
* The check for supported archive formats (currently only zip files) is performed on the original `archive_path` before copying or extraction, and the redundant post-copy validation has been removed. [[1]](diffhunk://#diff-bfa2cbff70f922fd2aef8a455d598da8c400ad4666771cbc5912fd81e6d5954fR128-R130) [[2]](diffhunk://#diff-bfa2cbff70f922fd2aef8a455d598da8c400ad4666771cbc5912fd81e6d5954fL132-L134)

**Project Metadata Update:**

* The license field in `pyproject.toml` now references the `LICENSE.txt` file instead of a string, improving standards compliance.